### PR TITLE
[Tests] fix WebTestBaseTest::testMsgUnexpectedRedirect, it passes now

### DIFF
--- a/tests/Test/WebTest/WebTestBaseTest.php
+++ b/tests/Test/WebTest/WebTestBaseTest.php
@@ -28,7 +28,7 @@ class WebTestBaseTest extends \PHPUnit\Framework\TestCase
 
     private function getMockClient($paramObj)
     {
-        $mClient = $this->createMock(Client::class);
+        $mClient = $this->getMockBuilder(Client::class)->setMethods(array('getResponse', 'getRequest'))->getMock();
 
         $mResponse = $this->getMockBuilder('dummy\Response')->setMethods(array('getTargetUrl'))->getMock();
         $mResponse->expects($this->any())->method('getTargetUrl')->willReturnCallback(function () use ($paramObj) {


### PR DESCRIPTION
Mocking did only work when the class did exist.