### PR TITLE
[CodeStyle] lint:xliff:cubestyle reports correct parameters as missing

### DIFF
--- a/src/CodeStyle/XliffFiles.php
+++ b/src/CodeStyle/XliffFiles.php
@@ -73,6 +73,8 @@ class XliffFiles
                 $node->setAttribute('id', $nId);
                 $node->removeAttribute('resname'); // unwanted
                 $fixed[] = 'id of "'.substr(strtr($sourceTxt, array("\n" => "\\n")), 0, 128).'"';
+            } else {
+                $fixed[] = 'TODO id invalid: '.$id;
             }
         }
         if (false !== strpos($sourceTxt, ' %') && false === self::getTranslatedParamPos($unit->filter('target')->text())) {
@@ -104,6 +106,14 @@ class XliffFiles
         }
     }
 
+    /**
+     * Check $id is valid for $sourceTxt.
+     *
+     * $id is invalid when:
+     *  * it is empty
+     *  * it contains '% '
+     *  * it is not contained in $sourceTxt
+     */
     private static function invalidId($id, $sourceTxt)
     {
         return !$id || false !== strpos($id, ' %') ||

--- a/src/CodeStyle/XliffFiles.php
+++ b/src/CodeStyle/XliffFiles.php
@@ -83,7 +83,7 @@ class XliffFiles
     /**
      * Check if translation contains something looking like a parameter.
      *
-     * The translated text can also contain the parameter inside quotes.
+     * The translated text can also contain the parameter inside quotes. (The original text (label) can not.)
      *
      * @return int|false
      */
@@ -95,8 +95,9 @@ class XliffFiles
             return $pos2;
         }
         $atPos1 = strtolower(substr($string, $pos2 - 1, 1));
-        if ($atPos1 < 'a' || $atPos1 > 'z') {
-            return $pos2 - 1;
+        if ($atPos1 < 'a' && '%' !== $atPos1 || $atPos1 > 'z') {
+            // looks like a parameter start (like '"%', ' %' or '(%', but not '%%')
+            return $pos2;
         } else {
             // look for next % character
             return self::getTranslatedParamPos($string, $pos2 + 1);

--- a/src/CodeStyle/XliffFiles.php
+++ b/src/CodeStyle/XliffFiles.php
@@ -75,8 +75,31 @@ class XliffFiles
                 $fixed[] = 'id of "'.substr(strtr($sourceTxt, array("\n" => "\\n")), 0, 128).'"';
             }
         }
-        if (false !== strpos($sourceTxt, ' %') && false === strpos($unit->filter('target')->text(), ' %')) {
+        if (false !== strpos($sourceTxt, ' %') && false === self::getTranslatedParamPos($unit->filter('target')->text())) {
             $fixed[] = 'TODO include parameters in source "'.strtr($sourceTxt, array("\n", "\\n")).'" (from target )';
+        }
+    }
+
+    /**
+     * Check if translation contains something looking like a parameter.
+     *
+     * The translated text can also contain the parameter inside quotes.
+     *
+     * @return int|false
+     */
+    private static function getTranslatedParamPos($string, $offset = 0)
+    {
+        $pos2 = strpos($string, '%', $offset);
+        if (false === $pos2 || 0 === $pos2) {
+            // not found, or at start
+            return $pos2;
+        }
+        $atPos1 = strtolower(substr($string, $pos2 - 1, 1));
+        if ($atPos1 < 'a' || $atPos1 > 'z') {
+            return $pos2 - 1;
+        } else {
+            // look for next % character
+            return self::getTranslatedParamPos($string, $pos2 + 1);
         }
     }
 

--- a/src/CodeStyle/check-shared.sh
+++ b/src/CodeStyle/check-shared.sh
@@ -131,6 +131,7 @@ checkTranslations () {
 }
 
 runCheckTranslation() {
+    $gitListFiles -- '*.xliff' '*.xlf' | $xArgs0 -- bin/console lint:xliff:cubestyle || showWarning
     $gitListFiles --quiet  -- '*.xliff' '*.xlf' || checkTranslations
 }
 

--- a/src/Command/CheckXliffFiles.php
+++ b/src/Command/CheckXliffFiles.php
@@ -61,6 +61,7 @@ EoMsg
         if ($nErrors) {
             $msg = '<comment>%s</>: <error>%d Errors</> in <error>%d</> files (checked %d of %d)';
             $output->writeln(\sprintf($msg, $this->getName(), $nErrors, $eFiles, $cFiles, \count($files)));
+            !$doFix && $output->writeln(\sprintf('fix with running: %s --fix ...', $this->getName()));
         } else {
             $output->writeln(\sprintf('%s: <info>[OK] checked %d files</>', $this->getName(), \count($files)));
         }

--- a/src/Command/CheckXliffFiles.php
+++ b/src/Command/CheckXliffFiles.php
@@ -2,12 +2,12 @@
 
 namespace CubeTools\CubeCommonDevelop\Command;
 
+use CubeTools\CubeCommonDevelop\CodeStyle\XliffFiles;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use CubeTools\CubeCommonDevelop\CodeStyle\XliffFiles;
 
 class CheckXliffFiles extends Command
 {


### PR DESCRIPTION
Before parameters at start or in quotes where not seen.