### PR TITLE
[Test] use annotations to be runnable with phpunit8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "phpstan/phpstan": "to check more things in the code"
     },
     "conflict": {
-        "phpunit/phpunit": "^8",
         "doctrine/orm": "<2.5.0"
     },
     "autoload": {

--- a/src/Test/App/SymfonyLoadableTest.php
+++ b/src/Test/App/SymfonyLoadableTest.php
@@ -28,7 +28,10 @@ class SymfonyLoadableTest extends TestCase
      */
     private static $console;
 
-    public static function setUpBeforeClass()
+    /**
+     * @beforeClass
+     */
+    public static function setUpPathBeforeClass()
     {
         $executableFinder = new PhpExecutableFinder();
         self::$php = $executableFinder->find();

--- a/src/Test/Resources/MatchingRoutesTest.php
+++ b/src/Test/Resources/MatchingRoutesTest.php
@@ -11,7 +11,10 @@ class MatchingRoutesTest extends KernelTestCase
 {
     private static $router;
 
-    public static function setUpBeforeClass()
+    /**
+     * @beforeClass
+     */
+    public static function setUpRouterBeforeClass()
     {
         static::bootKernel();
         self::$router = self::$kernel->getContainer()->get('router');

--- a/src/Test/WebTest/WebTestBase.php
+++ b/src/Test/WebTest/WebTestBase.php
@@ -195,8 +195,10 @@ class WebTestBase extends WebTestCase
      * Clear the cached client for a clean start of the next test case class.
      *
      * This method is called after all test methods of this class have run.
+     *
+     * @afterClass
      */
-    public static function tearDownAfterClass()
+    public static function tearDownClientAfterClass()
     {
         if (self::$client) { // only when valid client
             self::$client = null;


### PR DESCRIPTION
Because setUp() and similar methods require type hinting for phpunit8.